### PR TITLE
Improve README navigation and license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Andre Luiz Barbosa
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/readme.md
+++ b/readme.md
@@ -128,16 +128,48 @@
     <a href = "#java-projects">
   <img align="center" alt="Andrehlb-Java" height="30" width="40" src="https://raw.githubusercontent.com/devicons/devicon/master/icons/java/java-plain.svg">
    </a>
-    <a href="#js-projects">
-  <img align="center" alt="Andrejlb-Js" height="30" width="40" src="https://raw.githubusercontent.com/devicons/devicon/master/icons/javascript/javascript-plain.svg">
+  <a href="#js-projects">
+  <img align="center" alt="Andrehlb-Js" height="30" width="40" src="https://raw.githubusercontent.com/devicons/devicon/master/icons/javascript/javascript-plain.svg">
   </a>
-  <a href = "https://github.com/Andrehlb/WebDevelpment.git" target = "_blank"><img align="center" alt="Andrehlb-HTML" height="30" width="40" src="https://raw.githubusercontent.com/devicons/devicon/master/icons/html5/html5-original.svg">
-  <img align="center" alt="Andrehlb-CSS" height="30" width="40" src="https://raw.githubusercontent.com/devicons/devicon/master/icons/css3/css3-original.svg">   
+  <a href = "https://github.com/Andrehlb/WebDevelopment" target = "_blank"><img align="center" alt="Andrehlb-HTML" height="30" width="40" src="https://raw.githubusercontent.com/devicons/devicon/master/icons/html5/html5-original.svg">
+  <img align="center" alt="Andrehlb-CSS" height="30" width="40" src="https://raw.githubusercontent.com/devicons/devicon/master/icons/css3/css3-original.svg">
    </a>
   <a href= "#dart-projects">
   <img align="center" alt="Andrehlb-Dart" height="30" width="40" src="https://raw.githubusercontent.com/devicons/devicon/master/icons/dart/dart-plain.svg">
   </p>
 </div>
+
+---
+
+## Project Index
+
+### <a id="dataScience-projects"></a> Data Science
+- [AI - Naive Bayes Classifier](https://github.com/Andrehlb/AI-NaiveBayes-Classifier)
+- [Generative AI Azure Copilot OpenAI](https://github.com/Andrehlb/generative-AI-Azure-Copilot-OpenAI)
+- [Data Science Embraer](https://github.com/Andrehlb/DataScience_Embraer)
+- [Data Science Unimed BH](https://github.com/Andrehlb/Data-Science-Unimed_BH)
+
+### <a id="py-projects"></a> Python
+- [Simple Banking System - DB & Crypto Token](https://github.com/Andrehlb/SimpleBankingSystem-DB-Crypto-token.git)
+- [Task Manager API (Flask)](https://github.com/Andrehlb/TaskManager-Python.git)
+- [Auto Event Google Calendar](https://github.com/Andrehlb/auto-event-google-calendar)
+- [Web Page using PyScript](https://github.com/Andrehlb/Web-Page-using-PyScript)
+
+### <a id="R-projects"></a> R
+- [R-Universe](https://github.com/Andrehlb/R-Universe)
+
+### <a id="java-projects"></a> Java
+- [Java RESTful API - League of Legends](https://github.com/Andrehlb/Java-RestFul-API-SpringBoot-LeagueOfLegends-Santander)
+
+### <a id="js-projects"></a> JavaScript
+- [Task Manager API (Fastify)](https://github.com/Andrehlb/TaskManager-Fastify-React.git)
+- [Consumindo API](https://github.com/Andrehlb/consumindoAPI)
+- [Loja Esportiva AWS](https://github.com/Andrehlb/lojaEsportiva-AWS)
+- [HTML & JavaScript Tax Calculator](https://github.com/Andrehlb/Calculadora-Impostos-Vendas-JavaScript)
+
+### <a id="dart-projects"></a> Dart
+Projetos em Flutter e Dart em desenvolvimento.
+
   
 <div align="center">
 
@@ -166,6 +198,9 @@
 
 
 ## <div align = "center">Andrehlb's Profile </div>
+
+### License
+This project is released under the [MIT License](LICENSE).
 
 
 


### PR DESCRIPTION
## Summary
- fix JavaScript badge alt text
- correct Web Development repo URL
- add project index sections linked from badges
- add MIT license and mention it in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f5523738c8329a304d74d59aeef24